### PR TITLE
fix: fixed the logic of prod env check

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,6 +1,6 @@
 import { BASE_URL } from '@/constants';
 
-export const isProduct = () => process.env.VERCEL_ENV === 'product';
+export const isProduct = () => process.env.NODE_ENV === 'production';
 
 /**
  * 判断是否客户端


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use `process.env.NODE_ENV === 'production'` in `isProduct` instead of `process.env.VERCEL_ENV === 'product'`